### PR TITLE
Add redirect for start.hackmit.org

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,10 @@
 
     ga('create', '{{ site.analytics.tracking_id }}', 'auto');
     ga('send', 'pageview');
-
+  </script>
+  <script>
+    if (window.location.hostname == "start.hackmit.org") {
+      window.location.hostname = "starthacking.org"
+    }
   </script>
 </head>


### PR DESCRIPTION
Create a redirect for http://start.hackmit.org and all associated pages, so that it redirects to the relevant page on http://starthacking.org
