### PR TITLE
Add barebones "First Steps" to the GNU/Linux page

### DIFF
--- a/gnu-linux/index.md
+++ b/gnu-linux/index.md
@@ -4,10 +4,10 @@ title: GNU/Linux
 ---
 
 # First Steps
-There are many different linux distros, but this guide is going to cover Ubuntu, which is one of the most common ones. The first thing you're going to need is the `build-essential` package, which contains the `gcc` and `g++` compilers, as well as the common build tool `make`. In order to do this, simply run (on the command line) `apt-get install build-essential`.   
+There are many different GNU/Linux distros, but this guide is going to cover Ubuntu, which is one of the more common ones. The first thing you're going to need is the `build-essential` package, which contains the `gcc` and `g++` compilers, as well as the common build tool `make`. In order to do this, simply run (on the command line) `apt-get install build-essential`.   
 
 # Editors
-If you're planning to write code, you're going to need a way to edit files! If you enjoy working on the command line, we'd recommend either `vim` or `nano`, while if you prefer a GUI, we recommend either [Atom](https://atom.io) or [Brackets](https://brackets.io).
+If you're planning to write code, you're going to need a way to edit files! The first thing you'll need to decide while picking an editor is whether you prefer a graphical editor (you interact using a mouse), or a keystroke based editor if you are very comfortable on the command line. Two of the most popular graphical editors are [Atom](https://atom.io) and [Brackets](https://brackets.io), while two of the most popular keystoke based editors are `vim` and `emacs`.
 
 # Getting Started with [x]
 

--- a/gnu-linux/index.md
+++ b/gnu-linux/index.md
@@ -3,6 +3,12 @@ layout: page
 title: GNU/Linux
 ---
 
+# First Steps
+There are many different linux distros, but this guide is going to cover Ubuntu, which is one of the most common ones. The first thing you're going to need is the `build-essential` package, which contains the `gcc` and `g++` compilers, as well as the common build tool `make`. In order to do this, simply run (on the command line) `apt-get install build-essential`.   
+
+# Editors
+If you're planning to write code, you're going to need a way to edit files! If you enjoy working on the command line, we'd recommend either `vim` or `nano`, while if you prefer a GUI, we recommend either [Atom](https://atom.io) or [Brackets](https://brackets.io).
+
 # Getting Started with [x]
 
 {% for post in site.posts %}

--- a/gnu-linux/index.md
+++ b/gnu-linux/index.md
@@ -7,7 +7,7 @@ title: GNU/Linux
 There are many different GNU/Linux distros, but this guide is going to cover Ubuntu, which is one of the more common ones. The first thing you're going to need is the `build-essential` package, which contains the `gcc` and `g++` compilers, as well as the common build tool `make`. In order to do this, simply run (on the command line) `apt-get install build-essential`.   
 
 # Editors
-If you're planning to write code, you're going to need a way to edit files! The first thing you'll need to decide while picking an editor is whether you prefer a graphical editor (you interact using a mouse), or a keystroke based editor if you are very comfortable on the command line. Two of the most popular graphical editors are [Atom](https://atom.io) and [Brackets](https://brackets.io), while two of the most popular keystoke based editors are `vim` and `emacs`.
+If you're planning to write code, you're going to need a way to edit files! The first thing you'll need to decide while picking an editor is whether you prefer a graphical editor or a keystroke based editor. A graphical editor is like a normal computer program, where you interact with your mouse and keyboard. A keystroke based editor is an editor where you interact using your keyboard for everything. We only recommend keystroke based editors once you are more comfortable while programming. Two of the most popular graphical editors are [Atom](https://atom.io) and [Brackets](https://brackets.io), while two of the most popular keystoke based editors are `vim` and `emacs`.
 
 # Getting Started with [x]
 


### PR DESCRIPTION
I added a basic paragraph going through installing `build-essential` on Ubuntu, as well as editor recommendations. I don't know if you're planning on having multiple pages for different distros, so the instructions I wrote are Ubuntu-only. I'd be open to writing steps for other distros.